### PR TITLE
fix: Update getAllCookie.js

### DIFF
--- a/src/routines/getAllCookies.js
+++ b/src/routines/getAllCookies.js
@@ -6,6 +6,6 @@ import type {Page} from 'puppeteer';
  * @see https://stackoverflow.com/a/59604510/368691
  */
 export default (page: Page) => {
-  let client = typeof page._client == "function" ? page._client() : page._client;
+  const client = typeof page._client === 'function' ? page._client() : page._client;
   return client.send('Network.getAllCookies');
 };

--- a/src/routines/getAllCookies.js
+++ b/src/routines/getAllCookies.js
@@ -6,5 +6,6 @@ import type {Page} from 'puppeteer';
  * @see https://stackoverflow.com/a/59604510/368691
  */
 export default (page: Page) => {
-  return page._client.send('Network.getAllCookies');
+  let client = typeof page._client == "function" ? page._client() : page._client;
+  return client.send('Network.getAllCookies');
 };


### PR DESCRIPTION
 here [puppeteer-proxy](https://github.com/natpacket/puppeteer-proxy)/[src](https://github.com/natpacket/puppeteer-proxy/tree/master/src)/[routines](https://github.com/natpacket/puppeteer-proxy/tree/master/src/routines)/getAllCookies.js:
we can see the code:
```
return page._client.send('Network.getAllCookies');
```
but there is no longer _client attribute with puppeteer 14.0.0.
so，i do this:
```
return page._client().send('Network.getAllCookies');
```
it can be running well